### PR TITLE
feat: ExtraFields.UseJSONTag

### DIFF
--- a/encoder.go
+++ b/encoder.go
@@ -21,6 +21,7 @@ type Encoder struct {
 		DetailedMap    bool
 		DetailedArray  bool
 		DeepJSON       bool
+		UseJSONTag     bool
 	}
 	ArrayJSONNotation bool
 	Separator         string
@@ -328,7 +329,12 @@ func (e *Encoder) fdumpStruct(w map[string]interface{}, s reflect.Value, roots [
 		if !s.Field(i).CanInterface() {
 			continue
 		}
-		croots := append(roots, s.Type().Field(i).Name)
+		var croots []string
+		if e.ExtraFields.UseJSONTag && s.Type().Field(i).Tag.Get("json") != "" {
+			croots = append(roots, s.Type().Field(i).Tag.Get("json"))
+		} else {
+			croots = append(roots, s.Type().Field(i).Name)
+		}
 		atLeastOneField = true
 		if err := e.fdumpInterface(w, s.Field(i).Interface(), croots); err != nil {
 			return err

--- a/helper.go
+++ b/helper.go
@@ -6,11 +6,11 @@ import (
 )
 
 // KeyFormatterFunc is a type for key formatting
-type KeyFormatterFunc func(s string) string
+type KeyFormatterFunc func(s string, level int) string
 
 // WithLowerCaseFormatter formats keys in lowercase
 func WithLowerCaseFormatter() KeyFormatterFunc {
-	return func(s string) string {
+	return func(s string, level int) string {
 		return strings.ToLower(s)
 	}
 }
@@ -18,22 +18,22 @@ func WithLowerCaseFormatter() KeyFormatterFunc {
 // WithDefaultLowerCaseFormatter formats keys in lowercase and apply default formatting
 func WithDefaultLowerCaseFormatter() KeyFormatterFunc {
 	f := WithDefaultFormatter()
-	return func(s string) string {
-		return strings.ToLower(f(s))
+	return func(s string, level int) string {
+		return strings.ToLower(f(s, level))
 	}
 }
 
 // WithDefaultUpperCaseFormatter formats keys in uppercase and apply default formatting
 func WithDefaultUpperCaseFormatter() KeyFormatterFunc {
 	f := WithDefaultFormatter()
-	return func(s string) string {
-		return strings.ToUpper(f(s))
+	return func(s string, level int) string {
+		return strings.ToUpper(f(s, level))
 	}
 }
 
 // WithDefaultFormatter is the default formatter
 func WithDefaultFormatter() KeyFormatterFunc {
-	return func(s string) string {
+	return func(s string, level int) string {
 		s = strings.Replace(s, " ", "_", -1)
 		s = strings.Replace(s, "/", "_", -1)
 		s = strings.Replace(s, ":", "_", -1)
@@ -43,7 +43,7 @@ func WithDefaultFormatter() KeyFormatterFunc {
 
 // NoFormatter doesn't do anything, so to be sure to avoid keys formatting, use only this formatter
 func NoFormatter() KeyFormatterFunc {
-	return func(s string) string {
+	return func(s string, level int) string {
 		return s
 	}
 }
@@ -78,14 +78,14 @@ func validAndNotEmpty(v reflect.Value) bool {
 
 func sliceFormat(s []string, formatters []KeyFormatterFunc) []string {
 	for i := range s {
-		s[i] = format(s[i], formatters)
+		s[i] = format(s[i], formatters, i)
 	}
 	return s
 }
 
-func format(s string, formatters []KeyFormatterFunc) string {
+func format(s string, formatters []KeyFormatterFunc, level int) string {
 	for _, f := range formatters {
-		s = f(s)
+		s = f(s, level)
 	}
 	return s
 }


### PR DESCRIPTION
if ExtraFields.UseJSONTag = true, the json annotation (if defined)
on struct is used to name the key.

The KeyFormatterFunc can now use the level of the key
a.b
a is on level 0, b on level 1.

It's now possible to write a formatter like that:

```go
e.Formatters = []dump.KeyFormatterFunc{
	func(s string, level int) string {
		if level == 0 {
			return strings.ToLower(s)
		}
		return s
	},
}
```

Signed-off-by: Yvonnick Esnault <yvonnick.esnault@corp.ovh.com>